### PR TITLE
Expose Dispatcher as a trait of Store

### DIFF
--- a/src/dispatcher/mod.rs
+++ b/src/dispatcher/mod.rs
@@ -1,0 +1,24 @@
+mod store;
+
+pub use self::store::*;
+
+/// Trait for types that allow dispatching actions.
+pub trait Dispatcher<A> {
+    type Output;
+    fn dispatch(&mut self, action: A) -> Self::Output;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mock::*;
+
+    #[test]
+    fn dispatch() {
+        let dispatcher: &mut Dispatcher<_, Output = _> = &mut MockDispatcher::default();
+
+        assert_eq!(dispatcher.dispatch(5), 5);
+        assert_eq!(dispatcher.dispatch(1), 1);
+        assert_eq!(dispatcher.dispatch(3), 3);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,10 +101,10 @@ extern crate rayon;
 mod macros;
 mod mock;
 
+mod dispatcher;
 mod reactor;
 mod reducer;
-mod store;
 
+pub use dispatcher::*;
 pub use reactor::*;
 pub use reducer::*;
-pub use store::*;


### PR DESCRIPTION
The idea is to allow generic decorators for [Store](https://docs.rs/reducer/1.0.0/reducer/struct.Store.html) that enhance it with functionality, e.g. asynchronous dispatching.